### PR TITLE
Compat base64 url safe

### DIFF
--- a/mixin.go
+++ b/mixin.go
@@ -197,7 +197,10 @@ func (ex *Exchange) refundSnapshot(ctx context.Context, s *Snapshot) error {
 func (ex *Exchange) decryptOrderAction(ctx context.Context, data string) (*OrderAction, error) {
 	payload, err := base64.StdEncoding.DecodeString(data)
 	if err != nil {
-		return nil, err
+		payload, err = base64.URLEncoding.DecodeString(data)
+		if err != nil {
+			return nil, err
+		}
 	}
 	var action OrderAction
 	decoder := codec.NewDecoderBytes(payload, ex.codec)


### PR DESCRIPTION
The base64 memo should be url safe,  web payment may fail, e.g  '+' in query param.
Switch all in url base64 StdEncoding to URLEncoding?
